### PR TITLE
Fix: Update Email Validation Regex for Improved Accuracy

### DIFF
--- a/lib/features/auth/pages/forget_password_page.dart
+++ b/lib/features/auth/pages/forget_password_page.dart
@@ -54,7 +54,7 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
         if (value?.isEmpty ?? true) {
           return 'Please enter your email';
         }
-        if (!RegExp(r'^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value!)) {
+        if (!RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$').hasMatch(value!)) {
           return 'Please enter a valid email';
         }
         return null;

--- a/lib/features/auth/pages/signin_page.dart
+++ b/lib/features/auth/pages/signin_page.dart
@@ -278,7 +278,7 @@ class _SignInPageState extends State<SignInPage>
                                         return 'Please enter your email';
                                       }
                                       if (!RegExp(
-                                              r'^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$')
+                                              r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')
                                           .hasMatch(value!)) {
                                         return 'Please enter a valid email';
                                       }

--- a/lib/features/auth/pages/signup_page.dart
+++ b/lib/features/auth/pages/signup_page.dart
@@ -320,7 +320,7 @@ class _SignUpPageState extends State<SignUpPage>
                                       return 'Please enter your email';
                                     }
                                     if (!RegExp(
-                                            r'^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$')
+                                            r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')
                                         .hasMatch(value!)) {
                                       return 'Please enter a valid email';
                                     }


### PR DESCRIPTION
This pull request updates the email validation regex in the authentication pages to improve accuracy and support a broader range of valid email formats. The previous regex was restrictive and did not allow for some valid email addresses. The updated regex is more permissive and adheres to standard email formatting rules.

**Changes:**

1. **Updated Regex:**
   - Old Regex: `r'^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$'`
   - New Regex: `r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'`

2. **Files Modified:**
   - `lib/features/auth/pages/forget_password_page.dart`
   - `lib/features/auth/pages/signin_page.dart`
   - `lib/features/auth/pages/signup_page.dart`

**Benefits:**

- Improved accuracy in email validation.
- Supports a wider range of valid email formats.
- Enhances user experience by allowing more users to successfully register and sign in.

**Testing:**

- Ensure that the updated regex does not falsely reject valid email addresses.
- Verify that the regex correctly identifies invalid email formats.
- Test the authentication flow with various email formats to confirm the changes.

**Reviewers:**

- Please assign this PR to a reviewer with expertise in authentication and regex validation.

**Checklist:**

- [ ] Code review completed.
- [ ] Unit tests passed.
- [ ] Integration tests passed.
- [ ] Manual testing completed.

Thank you for your review and approval!
